### PR TITLE
Fix permissions issue for picking contact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@remobile/react-native-contacts",
+    "name": "@SeshApp/react-native-contacts",
         "version": "1.0.1",
         "description": "A contacts for react-native",
         "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@SeshApp/react-native-contacts",
+    "name": "@remobile/react-native-contacts",
         "version": "1.0.1",
         "description": "A contacts for react-native",
         "main": "index.js",


### PR DESCRIPTION
Previously would silently fail if user hasn't authorized access to contacts.  The contacts view would still be shown but the returned contact would be nil.  This took me awhile to track down so if anyone else runs into the same issue, this is a quick-fix.

The more legit fix is probably to include permission checking for the other public methods as well and centralize this logic somewhere, possibly also exposing a checkPermissions function.
